### PR TITLE
Added invert() method to SSD1315 class

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ void loop() {
     display.sleep(true);
     delay(1000);
     display.sleep(false);
+    delay(2000);
 }
 ```
 

--- a/src/SSD1315.cpp
+++ b/src/SSD1315.cpp
@@ -65,6 +65,10 @@ void SSD1315::setBrightness(uint8_t level){
     command(level);
 }
 
+void SSD1315::invert(bool en){
+    command(en?0xA7:0xA6);
+}
+
 void SSD1315::sleep(bool en){
     command(en?0xAE:0xAF);
 }

--- a/src/SSD1315.cpp
+++ b/src/SSD1315.cpp
@@ -13,12 +13,14 @@ void SSD1315::command(uint8_t c){I2C_Write(c,0x00);}
 void SSD1315::data(uint8_t d){I2C_Write(d,0x40);} 
 
 void SSD1315::begin(){
-    pinMode(_rst,OUTPUT);
-    digitalWrite(_rst,HIGH);
-    delay(10);
-    digitalWrite(_rst,LOW);
-    delay(10);
-    digitalWrite(_rst,HIGH);
+    if (_rst < NO_RESET_PIN) {
+        pinMode(_rst,OUTPUT);
+        digitalWrite(_rst,HIGH);
+        delay(10);
+        digitalWrite(_rst,LOW);
+        delay(10);
+        digitalWrite(_rst,HIGH);
+    }
     command(0xae);
     command(0xd5);
     command(0x80);

--- a/src/SSD1315.h
+++ b/src/SSD1315.h
@@ -18,6 +18,8 @@
 #define SSD1315_HEIGHT 40
 #define SSD1315_PAGES (SSD1315_HEIGHT/8)
 
+#define NO_RESET_PIN 255
+
 class SSD1315 {
 public:
     SSD1315(uint8_t rstPin=8);

--- a/src/SSD1315.h
+++ b/src/SSD1315.h
@@ -25,6 +25,7 @@ public:
     void clear();
     void fill(uint8_t color);
     void display();
+    void invert(bool enable);
     void setRotation(uint8_t r);
     void setBrightness(uint8_t level);
     void sleep(bool enable);


### PR DESCRIPTION
This function `invert(val)` will invert the all the display pixels at once when `val = true` and will restore the display pixels at once if `val=false`. The content of the display buffer is not changed and there is no need to call the `display()` method.

Think of `invert` as an on/off switch, not as a toggle.

Also added a small correction to the example code in README.md.